### PR TITLE
Remove inheritance of params by repo class

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,7 +1,7 @@
 # PRIVATE CLASS: do not use directly
 class postgresql::repo (
   $version = undef
-) inherits postgresql::params {
+) {
   case $::osfamily {
     'RedHat', 'Linux': {
       if $version == undef {


### PR DESCRIPTION
Inheritance of postgresql::params by postgresql::repo causes this error (we override manage_package_repo and version in globals).  Removing inheritance worked with no side effects that we have seen so far.

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Could not find scope for postgresql::params at /etc/puppet/environments/myPuppetUpgrade/external/postgresql/manifests/globals.pp:119 on node node.example.com
